### PR TITLE
Remove verbose loading of .env file and better determine root dir

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,13 +1,13 @@
 import os
 from datetime import datetime
 from dotenv import load_dotenv, find_dotenv
-env_path = find_dotenv()
-load_dotenv(dotenv_path=env_path, verbose=True)
+
+load_dotenv(dotenv_path=find_dotenv())
 
 NOT_FOUND_MSG = 'Not found.'
 SERVER_ERROR_MSG = 'Internal server error.'
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
-ROOT_DIRECTORY = os.path.split(env_path)[0]
+ROOT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 
 def env(key, default=None):


### PR DESCRIPTION
### This PR removes verbosity when loading the .env file.
The verbosity is producing warnings in the absence of the `.env` file.

Initially, determining the root directory of the project relied on the successful location of the `.env` file. Now it is determined by the `utils` file itself with the help of the `os` module.