### PR TITLE
Add created_by column to entries

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -26,7 +26,7 @@ class EntryController:
     @staticmethod
     def create():
         validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
-        entry = Entry.create(request.form['title'], request.form['body'])
+        entry = Entry.create(request.form['title'], request.form['body'], auth.id())
         return jsonify({'entry': entry}), 201
 
     @staticmethod

--- a/app/models.py
+++ b/app/models.py
@@ -43,7 +43,7 @@ class Entry:
         return Entry.__db.get(entry_id)
 
     @staticmethod
-    def create(title, body):
+    def create(title, body, created_by):
         """
         Creates an entry and returns a copy.
         :rtype: dict
@@ -51,6 +51,7 @@ class Entry:
         return Entry.__db.insert({
             'title': title,
             'body': body,
+            'created_by': created_by
         })
 
     @staticmethod

--- a/schema/create.sql
+++ b/schema/create.sql
@@ -1,16 +1,17 @@
-create table if not exists entries (
-  id         serial    not null primary key,
-  title      varchar   not null,
-  body       text      not null,
-  created_at timestamp not null default now(),
-  updated_at timestamp          default current_timestamp
-);
-
 create table if not exists users (
   id         serial    not null primary key,
   name       varchar   not null,
   email      varchar   not null,
   password   varchar   not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp          default current_timestamp
+);
+
+create table if not exists entries (
+  id         serial    not null primary key,
+  title      varchar   not null,
+  body       text      not null,
+  created_by integer   not null references users (id),
   created_at timestamp not null default now(),
   updated_at timestamp          default current_timestamp
 );

--- a/tests/database_tests/query_test.py
+++ b/tests/database_tests/query_test.py
@@ -5,38 +5,38 @@ from tests.helpers import DBUtils
 
 
 class QueryTestCase(unittest.TestCase):
-    # before each test
+
     def setUp(self):
         self.table = 'entries'
         self.query = DBQuery(self.table)
-        self.db = DBUtils('entries')
+        self.db = DBUtils()
         self.db.create_schema()
 
     def test_it_inserts_records(self):
-        data = {'title': 'My title', 'body': 'My body'}
+        data = {'title': 'My title', 'body': 'My body', 'created_by': self.db.create_user()['id']}
         record = self.query.insert(data)
         self.assertDictContainsSubset(data, record)
 
     def test_it_updates_records(self):
-        self.db.create(10)
+        self.db.create_entry(3)
         data = {'title': 'Updated title', 'body': 'Updated body'}
-        updated = self.query.update(data, {'id': self.db.random()['id']})
+        updated = self.query.update(data, {'id': self.db.random_entry()['id']})
         self.assertDictContainsSubset(data, updated)
 
     def test_it_deletes_records(self):
-        self.db.create(10)
-        record = self.db.random()
+        self.db.create_entry()
+        record = self.db.random_entry()
         self.query.delete({'id': record['id']})
         self.assertEqual([], self.query.select('*', {'id': record['id']}))
 
     def test_it_gets_count_of_records(self):
         self.assertEqual(0, self.query.count())
-        self.db.create(5)
-        self.assertEqual(5, self.query.count())
+        self.db.create_entry(3)
+        self.assertEqual(3, self.query.count())
 
     def test_updated_at_column_is_updated(self):
-        self.db.create(10)
-        record = self.query.select('*', {'id': self.db.random()['id']})[0]
+        self.db.create_entry(3)
+        record = self.query.select('*', {'id': self.db.random_entry()['id']})[0]
         sleep(0.5)  # delay for 500ms before update
         self.query.update({'title': 'Tile', 'body': 'Body'}, {'id': record['id']})
         updated = self.query.select('*', {'id': record['id']})[0]

--- a/tests/entry_api_tests/base_test.py
+++ b/tests/entry_api_tests/base_test.py
@@ -8,7 +8,7 @@ class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
         self.fake = Faker()
-        self.db = DBUtils('entries')
+        self.db = DBUtils()
         self.db.create_schema()
         self.client = app.test_client(self)
         self.token = auth_token()

--- a/tests/entry_api_tests/delete_test.py
+++ b/tests/entry_api_tests/delete_test.py
@@ -6,14 +6,13 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class DeleteTestCase(BaseTestCase):
 
     def test_it_deletes_entries(self):
-        self.db.create(3)
-        response = self.delete('/api/v1/entries/2')
+        entry_id = self.db.create_entry()['id']
+        response = self.delete('/api/v1/entries/%s' % str(entry_id))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
         self.assertEqual({'message': 'Entry deleted.'}, json.loads(response.data))
-        # Ensure that entry with id == 2 no longer exists on the models
         all_entries = json.loads(self.get('/api/v1/entries').data)['entries']
-        self.assertFalse(any(entry['id'] == 2 for entry in all_entries))
+        self.assertFalse(any(entry['id'] == entry_id for entry in all_entries))
 
     def test_fails_on_model_not_found(self):
         response = self.delete('/api/v1/entries/71115')

--- a/tests/entry_api_tests/get_test.py
+++ b/tests/entry_api_tests/get_test.py
@@ -5,9 +5,9 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class GetTestCase(BaseTestCase):
 
     def test_it_gets_a_specific_entry(self):
-        records = self.db.create(4, select=['title', 'body'])
-        response = self.get('/api/v1/entries/4')
+        record = self.db.create_entry()
+        response = self.get('/api/v1/entries/%s' % str(record['id']))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
-        # The third index of records has id == 4
-        self.assertDictContainsSubset(records[3], json.loads(response.data)['entry'])
+        expected_data = {'title': record['title'], 'body': record['body']}
+        self.assertDictContainsSubset(expected_data, json.loads(response.data)['entry'])

--- a/tests/entry_api_tests/list_test.py
+++ b/tests/entry_api_tests/list_test.py
@@ -5,9 +5,10 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class ListTestCase(BaseTestCase):
 
     def test_it_lists_all_entries(self):
-        records = self.db.create(3, select=['title', 'body'])
+        records = self.db.create_entry(3)
         response = self.get('/api/v1/entries')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
-        filtered = [{'title': item['title'], 'body': item['body']} for item in json.loads(response.data)['entries']]
-        self.assertEqual(records, filtered)
+        expected = [{'title': item['title'], 'body': item['body']} for item in records]
+        received = [{'title': item['title'], 'body': item['body']} for item in json.loads(response.data)['entries']]
+        self.assertEqual(expected, received)

--- a/tests/entry_api_tests/stats_test.py
+++ b/tests/entry_api_tests/stats_test.py
@@ -5,11 +5,11 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class StatsTestCase(BaseTestCase):
 
     def test_it_gets_entry_count_stat(self):
-        self.db.create(4)
+        self.db.create_entry(3)
         response = self.get('/api/v1/entries/stats/count')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
-        self.assertEqual(4, json.loads(response.data)['count'])
+        self.assertEqual(3, json.loads(response.data)['count'])
 
     def test_entry_count_remains_accurate_after_creation(self):
         data = {'title': 'A title', 'body': 'This is a body'}
@@ -19,8 +19,8 @@ class StatsTestCase(BaseTestCase):
         self.assertEqual(new_count, old_count + 1)
 
     def test_entry_count_remains_accurate_after_deletion(self):
-        self.db.create(4)
+        self.db.create_entry(4)
         old_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']
-        self.delete('/api/v1/entries/4')
+        self.delete('/api/v1/entries/2')
         new_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']
         self.assertEqual(new_count, old_count - 1)

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -5,9 +5,9 @@ from tests.entry_api_tests.base_test import BaseTestCase
 
 class UpdateTestCase(BaseTestCase):
     def test_it_updates_entries(self):
-        self.db.create(4)
+        self.db.create_entry(3)
         updates = {'title': 'A new title', 'body': 'A new body'}
-        response = self.put('/api/v1/entries/3', data=updates)
+        response = self.put('/api/v1/entries/2', data=updates)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
         self.assertDictContainsSubset(updates, json.loads(response.data)['entry'])

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,8 +9,7 @@ class DBUtils:
     """
     This class allows for easy testing of the database. We must trust it.
     """
-    def __init__(self, table):
-        self.table = table
+    def __init__(self):
         self.fake = Faker()
         self.connection = DBConnection.get()
         self.connection.autocommit = True
@@ -22,33 +21,115 @@ class DBUtils:
     def create_schema(self):
         self.cursor.execute(open(full_path('schema/create.sql'), 'r').read())
 
-    def random(self):
-        self.cursor.execute("select id from entries order by random()")
-        return self.cursor.fetchone()
+    def random_user(self, count=1):
+        return self.random('users', count)
 
-    def create(self, count=1, select='*'):
-        records = []
+    def random_entry(self, count=1):
+        return self.random('entries', count)
+
+    def random(self, table, count=1):
+        query = sql.SQL("select * from {} order by random() limit {}").format(
+            sql.Identifier(table), sql.Placeholder()
+        )
+        self.cursor.execute(query, (count,))
+        items = self.cursor.fetchall()
+        return items[0] if count == 1 else items
+
+    def make_user(self, count=1, overrides=None):
+        """
+        Creates a dictionary containing values that can be used to create a user.
+        :param count:
+        :param overrides:
+        :return:
+        """
+        overrides = overrides if overrides else {}
+        override_fields = overrides.keys()
+        users = []
         for i in range(0, count):
-            self.cursor.execute(
-                sql.SQL("insert into {} (title, body) values(%s, %s) returning id").format(
-                    sql.Identifier(self.table)
-                ), (self.fake.sentence(), self.fake.text())
+            users.append(
+                {
+                    'name': overrides['name'] if 'name' in override_fields else self.fake.name(),
+                    'email': overrides['email'] if 'email' in override_fields else self.fake.email(),
+                    'password': overrides['password'] if 'password' in override_fields else self.fake.password()
+                }
             )
-            _id = [self.cursor.fetchone()['id']]
-            if select == '*':
-                self.cursor.execute(sql.SQL("select * from {} where id = {}").format(
-                    sql.Identifier(self.table), sql.Placeholder()
-                ), _id)
-            else:
-                self.cursor.execute(sql.SQL("select {} from {} where id = {}").format(
-                    sql.SQL(', ').join(map(sql.Identifier, select)),
-                    sql.Identifier(self.table),
-                    sql.Placeholder()
-                ), _id)
-            records.append(self.cursor.fetchone())
-        return records
+        return users[0] if count == 1 else users
+
+    def make_entry(self, count=1, overrides=None):
+        """
+        Creates a dictionary containing values that can be used to create an entry.
+        The created_by field holds an the id of a user on the database.
+        :param count:
+        :param overrides:
+        :return:
+        """
+        overrides = overrides if overrides else {}
+        override_fields = overrides.keys()
+        entries = []
+        for i in range(0, count):
+            entries.append({
+                'title': overrides['title'] if 'title' in override_fields else self.fake.name(),
+                'body': overrides['body'] if 'body' in override_fields else self.fake.email(),
+                'created_by': overrides['created_by'] if 'created_by' in override_fields else self.create_user()['id']
+            })
+        return entries[0] if count == 1 else entries
+
+    def create_user(self, count=1, overrides=None):
+        """
+        Whips up an email and persists it to the database.
+        :param count: int
+        :param overrides: None or dict
+        :return: list or dict
+        """
+        return self.create('users', 'user', ['name', 'email', 'password'], count, overrides)
+
+    def create_entry(self, count=1, overrides=None):
+        """
+        Whips up an entry and persists it to the database.
+        :param count: int
+        :param overrides: None or dict
+        :return: list or dict
+        """
+        return self.create('entries', 'entry', ['title', 'body', 'created_by'], count, overrides)
+
+    def create(self, table, model, fields, count=1, overrides=None):
+        """
+        Whips up an item and persists it to the database.
+        Insert sample query: "insert into x (a, b, c) values (x, y, z) returning id"
+        Retrieve entry sample query: "select * from entries where id in (2, 3, 4)"
+        :param table: str
+        :param model: str
+        :param fields: list
+        :param count: int
+        :param overrides: None or dict
+        :return: list or dict
+        """
+        overrides = overrides if overrides else {}
+        item_ids = []
+        for i in range(0, count):
+            # build insert query string
+            query = sql.SQL("insert into {} ({}) values ({}) returning id").format(
+                sql.Identifier(table),
+                sql.SQL(', ').join(map(sql.Identifier, fields)),
+                sql.SQL(', ').join(sql.Placeholder() * len(fields))
+            )
+            # make random values
+            make_method = getattr(self, 'make_' + model)
+            random_values = list(make_method(overrides=overrides).values())
+            # insert item
+            self.cursor.execute(query, random_values)
+            # get id of inserted item
+            item_ids.append(self.cursor.fetchone()['id'])
+        # build query to retrieve just inserted item
+        query = sql.SQL("select * from {} where id in ({})").format(
+            sql.Identifier(table),
+            sql.SQL(', ').join(sql.Placeholder() * len(item_ids))
+        )
+        # retrieve just inserted items
+        self.cursor.execute(query, item_ids)
+        return self.cursor.fetchone() if count == 1 else self.cursor.fetchall()
 
 
 def auth_token():
-    user = User.create('Mutai Mwiti', 'mutaimwiti@code.com', 'secret')
+    user = User.create('Mutai Mwiti', 'mutaimwiti40@gmail.com', 'secret')
     return User.generate_token(user)

--- a/tests/model_tests/entry_test.py
+++ b/tests/model_tests/entry_test.py
@@ -5,18 +5,17 @@ from app.models import Entry, ModelNotFoundException
 
 class EntryModelTestCase(unittest.TestCase):
     def setUp(self):
-        self.db = DBUtils('entries')
+        self.db = DBUtils()
         self.db.create_schema()
 
     def test_it_lists_all_entries(self):
-        records = self.db.create(10)
+        records = self.db.create_entry(10)
         self.assertEqual(records, Entry.all())
 
     def test_it_gets_a_specific_entry(self):
-        # The second index of dummy entries has id == 3
-        records = self.db.create(10)
-        self.assertEqual(records[2], Entry.get(3))
-        self.assertNotEqual(records[3], Entry.get(3))
+        self.db.create_entry(4)
+        entry = self.db.random_entry()
+        self.assertEqual(entry, Entry.get(entry['id']))
         # Fails for non-existent entries
         with self.assertRaises(ModelNotFoundException):
             Entry.get(51115)
@@ -24,11 +23,11 @@ class EntryModelTestCase(unittest.TestCase):
     def test_it_creates_new_entries(self):
         title = 'A title'
         body = 'A body'
-        new_entry = Entry.create(title, body)
+        new_entry = Entry.create(title, body, self.db.create_user()['id'])
         self.assertDictContainsSubset({'title': title, 'body': body}, new_entry)
 
     def test_it_updates_entries(self):
-        self.db.create(10)
+        self.db.create_entry(10)
         title = 'A new title'
         body = 'A new body'
         updated_entry = Entry.update(2, title, body)
@@ -39,21 +38,21 @@ class EntryModelTestCase(unittest.TestCase):
             Entry.update(71115, 'Foo', 'Bar')
 
     def test_it_deletes_entries(self):
-        self.db.create(10)
+        self.db.create_entry(4)
         self.assertTrue(Entry.delete(3))
         # Fails for non-existent entries
         with self.assertRaises(ModelNotFoundException):
             Entry.delete(91155)
 
     def test_it_gets_entry_count(self):
-        self.db.create(15)
-        self.assertEqual(15, Entry.count())
+        self.db.create_entry(6)
+        self.assertEqual(6, Entry.count())
 
     def test_entry_count_is_always_accurate(self):
-        self.db.create(5)
+        self.db.create_entry(5)
         # when new entry is created
         count_before = Entry.count()
-        Entry.create('A title', 'A body')
+        Entry.create('A title', 'A body', self.db.create_user()['id'])
         count_after = Entry.count()
         self.assertEqual(count_after, count_before + 1)
         # when an entry is deleted

--- a/tests/model_tests/user_test.py
+++ b/tests/model_tests/user_test.py
@@ -5,12 +5,12 @@ from app.models import User
 
 class EntryModelTestCase(unittest.TestCase):
     def setUp(self):
-        self.db = DBUtils('users')
+        self.db = DBUtils()
         self.db.create_schema()
 
     def test_it_creates_user(self):
         name = 'Mutai Mwiti'
-        email = 'mutaimwiti@code.com'
+        email = 'mutaimwiti40@gmail.com'
         # new user
         user = User.create(name, email, 'secret')
         self.assertDictContainsSubset({'name': name, 'email': email}, user)
@@ -18,7 +18,7 @@ class EntryModelTestCase(unittest.TestCase):
         self.assertFalse(User.create(name, email, 'secret'))
 
     def test_it_checks_user_credentials(self):
-        email = 'mutaimwiti@code.com'
+        email = 'mutaimwiti40@gmail.com'
         password = 'secret'
         # create user
         User.create('Mutai Mwiti', email, password)


### PR DESCRIPTION
This PR delivers the creation of `created_by` column to entries table.

This makes it possible to track blogs by their owner.