### PR TITLE
Filter entries by created_by

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -28,13 +28,17 @@ class EntryController:
     @staticmethod
     def create():
         validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
-        entry = Entry.create(request.form['title'], request.form['body'], auth.id())
+        entry = Entry.create(request.form.get('title'), request.form.get('body'), auth.id())
         return jsonify({'entry': entry}), 201
 
     @staticmethod
     def update(entry_id):
         validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
-        entry = Entry.update({'id': entry_id, 'created_by': auth.id()}, request.form['title'], request.form['body'])
+        entry = Entry.update(
+            {'id': entry_id, 'created_by': auth.id()},
+            request.form.get('title'),
+            request.form.get('body')
+        )
         return jsonify({'entry': entry}), 200
 
     @staticmethod
@@ -51,7 +55,7 @@ class UserController:
     def signup():
         # create a new user
         validate(request.form, {'name': 'required', 'email': 'required|email', 'password': 'required|min:6'})
-        created = User.create(request.form['name'], request.form['email'], request.form['password'])
+        created = User.create(request.form.get('name'), request.form.get('email'), request.form.get('password'))
         if created is False:
             return jsonify({'message': 'A user with the same email address exists.'}), 409
         return jsonify({'message': 'User created.'}), 201
@@ -90,14 +94,14 @@ class UserController:
             token = None
 
             if 'x-access-token' in request.headers:
-                token = request.headers['x-access-token']
+                token = request.headers.get('x-access-token')
 
             if not token:
                 return jsonify({'error': 'Authentication is required.'}), 401
 
             try:
                 data = jwt.decode(token, env('APP_KEY'))
-                auth.set(data['user'])
+                auth.set(data.get('user'))
             except:
                 return jsonify({'error': 'Invalid access token.'}), 401
 

--- a/app/controllers.py
+++ b/app/controllers.py
@@ -16,12 +16,13 @@ class EntryController:
 
     @staticmethod
     def all():
-        entries = Entry.all()
+        entries = Entry.all({'created_by': auth.id()})
         return jsonify({'entries': entries, 'count': len(entries)}), 200
 
     @staticmethod
     def get(entry_id):
-        return jsonify({'entry': Entry.get(entry_id)}), 200
+        entry = Entry.get({'id': entry_id, 'created_by': auth.id()})
+        return jsonify({'entry': entry}), 200
 
     @staticmethod
     def create():
@@ -32,12 +33,12 @@ class EntryController:
     @staticmethod
     def update(entry_id):
         validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
-        entry = Entry.update(entry_id, request.form['title'], request.form['body'])
+        entry = Entry.update({'id': entry_id, 'created_by': auth.id()}, request.form['title'], request.form['body'])
         return jsonify({'entry': entry}), 200
 
     @staticmethod
     def delete(entry_id):
-        Entry.delete(entry_id)
+        Entry.delete({'id': entry_id, 'created_by': auth.id()})
         return jsonify({'message': 'Entry deleted.'}), 200
 
 

--- a/app/controllers.py
+++ b/app/controllers.py
@@ -12,7 +12,8 @@ class EntryController:
 
     @staticmethod
     def count():
-        return jsonify({'count': Entry.count()}), 200
+        entry = Entry.count({'created_by': auth.id()})
+        return jsonify({'count': entry}), 200
 
     @staticmethod
     def all():

--- a/app/database.py
+++ b/app/database.py
@@ -45,7 +45,23 @@ class DBQuery:
         self.cursor = self.connection.cursor(cursor_factory=extras.RealDictCursor)
 
     @staticmethod
-    def attribute_equals_value(attributes):
+    def __x_equals_y_comma_clause(attributes):
+        """
+        An sql generator for a = b, j = k, m = n ...
+        :param attributes:
+        """
+        aggregate = []
+        for item in attributes:
+
+            aggregate.append(
+                sql.SQL("{} = {}").format(
+                    sql.Identifier(item), sql.Placeholder()
+                )
+            )
+        return sql.SQL(', ').join(aggregate)
+
+    @staticmethod
+    def __x_equals_y_and_clause(attributes):
         """
         An sql generator for a = b, j = k, m = n ...
         :param attributes:
@@ -57,13 +73,25 @@ class DBQuery:
                     sql.Identifier(item), sql.Placeholder()
                 )
             )
-        return sql.SQL(', ').join(aggregate)
+        return sql.SQL(' and ').join(aggregate)
 
-    def exists(self, _id):
-        return False if self.get(_id) is None else True
+    def exists(self, filters):
+        """
+        filters is a dictionary specifying the filtering criteria
+        to be applied e.g {'id': 25, created_by' = 10}.
+        :param filters:
+        :return:
+        """
+        return False if self.get(filters) is None else True
 
-    def get(self, _id):
-        entry = self.select('*', {'id': _id})
+    def get(self, filters):
+        """
+        filters is a dictionary specifying the filtering criteria
+        to be applied e.g {'id': 25, created_by' = 10}.
+        :param filters:
+        :return:
+        """
+        entry = self.select('*', filters)
         return entry[0] if len(entry) > 0 else None
 
     def insert(self, data):
@@ -81,8 +109,8 @@ class DBQuery:
             sql.SQL(', ').join(sql.Placeholder() * len(fields))
         )
         self.cursor.execute(query, values)
-        _id = self.cursor.fetchone()['id']
-        return self.get(_id)
+        item_id = self.cursor.fetchone()['id']
+        return self.get({'id': item_id})
 
     def update(self, data, filters):
         """
@@ -97,13 +125,13 @@ class DBQuery:
         """
         query = sql.SQL("update {} set {} where {} returning id").format(
             sql.Identifier(self.table),
-            DBQuery.attribute_equals_value(data),
-            DBQuery.attribute_equals_value(filters)
+            DBQuery.__x_equals_y_comma_clause(data),
+            DBQuery.__x_equals_y_and_clause(filters)
         )
         values = list(data.values()) + list(filters.values())
         self.cursor.execute(query, values)
-        _id = self.cursor.fetchone()['id']
-        return self.get(_id)
+        item_id = self.cursor.fetchone()['id']
+        return self.get({'id': item_id})
 
     def delete(self, filters):
         """
@@ -114,7 +142,7 @@ class DBQuery:
         # delete from table where condition
         query = sql.SQL("delete from {} where {}").format(
             sql.Identifier(self.table),
-            DBQuery.attribute_equals_value(filters)
+            DBQuery.__x_equals_y_and_clause(filters)
         )
         self.cursor.execute(query, list(filters.values()))
 
@@ -137,7 +165,7 @@ class DBQuery:
             else:
                 query = sql.SQL("select * from {} where {}").format(
                     sql.Identifier(self.table),
-                    DBQuery.attribute_equals_value(filters)
+                    DBQuery.__x_equals_y_and_clause(filters)
                 )
                 self.cursor.execute(query, list(filters.values()))
         else:
@@ -151,18 +179,25 @@ class DBQuery:
                 query = sql.SQL("select {} from {} where {}").format(
                     sql.SQL(', ').join(map(sql.Identifier, fields)),
                     sql.Identifier(self.table),
-                    DBQuery.attribute_equals_value(filters)
+                    DBQuery.__x_equals_y_and_clause(filters)
                 )
                 self.cursor.execute(query, list(filters.values()))
         return self.cursor.fetchall()
 
-    def count(self):
+    def count(self, filters=None):
         """
         Gets the row count for the table.
         :return: int
         """
-        query = sql.SQL("select count(*) from {}").format(sql.Identifier(self.table))
-        self.cursor.execute(query)
+        if filters is None:
+            query = sql.SQL("select count(*) from {}").format(sql.Identifier(self.table))
+            self.cursor.execute(query)
+        else:
+            query = sql.SQL("select count(*) from {} where {}").format(
+                sql.Identifier(self.table),
+                DBQuery.__x_equals_y_and_clause(filters)
+            )
+            self.cursor.execute(query, list(filters.values()))
         return self.cursor.fetchone()['count']
 
     def raw(self, query, fetch=False):

--- a/app/database.py
+++ b/app/database.py
@@ -109,7 +109,7 @@ class DBQuery:
             sql.SQL(', ').join(sql.Placeholder() * len(fields))
         )
         self.cursor.execute(query, values)
-        item_id = self.cursor.fetchone()['id']
+        item_id = self.cursor.fetchone().get('id')
         return self.get({'id': item_id})
 
     def update(self, data, filters):
@@ -130,7 +130,7 @@ class DBQuery:
         )
         values = list(data.values()) + list(filters.values())
         self.cursor.execute(query, values)
-        item_id = self.cursor.fetchone()['id']
+        item_id = self.cursor.fetchone().get('id')
         return self.get({'id': item_id})
 
     def delete(self, filters):
@@ -198,7 +198,7 @@ class DBQuery:
                 DBQuery.__x_equals_y_and_clause(filters)
             )
             self.cursor.execute(query, list(filters.values()))
-        return self.cursor.fetchone()['count']
+        return self.cursor.fetchone().get('count')
 
     def raw(self, query, fetch=False):
         self.cursor.execute(query)

--- a/app/models.py
+++ b/app/models.py
@@ -122,7 +122,7 @@ class User:
     def generate_token(user):
         # token payload
         payload = {
-            'user': user['email'],
+            'user': user.get('email'),
             'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=int(env('SESSION_LIFETIME')))
         }
         return jwt.encode(payload, env('APP_KEY'))

--- a/app/models.py
+++ b/app/models.py
@@ -16,31 +16,31 @@ class Entry:
         pass
 
     @staticmethod
-    def __check(entry_id):
-        if Entry.__db.exists(entry_id) is False:
+    def __check(filters):
+        if Entry.__db.exists(filters) is False:
             raise ModelNotFoundException
 
     @staticmethod
-    def count():
-        return Entry.__db.count()
+    def count(filters=None):
+        return Entry.__db.count(filters)
 
     @staticmethod
-    def all():
+    def all(filters=None):
         """
         Returns all the entries.
         :rtype: list
         """
-        return Entry.__db.select('*')
+        return Entry.__db.select('*', filters)
 
     @staticmethod
-    def get(entry_id):
+    def get(filters):
         """
         Returns the specified entry.
-        :param entry_id:
+        :param filters:
         :rtype: dict or None
         """
-        Entry.__check(entry_id)
-        return Entry.__db.get(entry_id)
+        Entry.__check(filters)
+        return Entry.__db.get(filters)
 
     @staticmethod
     def create(title, body, created_by):
@@ -55,26 +55,26 @@ class Entry:
         })
 
     @staticmethod
-    def update(entry_id, title, body):
+    def update(filters, title, body):
         """
         Updates the specified entry.
-        :param entry_id:
+        :param filters:
         :param title:
         :param body:
         :rtype: dict
         """
-        Entry.__check(entry_id)
-        return Entry.__db.update({'title': title, 'body': body}, {'id': entry_id})
+        Entry.__check(filters)
+        return Entry.__db.update({'title': title, 'body': body}, filters)
 
     @staticmethod
-    def delete(entry_id):
+    def delete(filters):
         """
         Deletes the specified entry.
-        :param entry_id:
+        :param filters:
         :rtype: bool
         """
-        Entry.__check(entry_id)
-        Entry.__db.delete({'id': entry_id})
+        Entry.__check(filters)
+        Entry.__db.delete(filters)
         return True
 
 

--- a/app/request.py
+++ b/app/request.py
@@ -231,7 +231,7 @@ class Auth:
 
     @staticmethod
     def id():
-        return Auth.user()['id']
+        return Auth.user().get('id')
 
     @staticmethod
     def email():

--- a/tests/database_tests/query_test.py
+++ b/tests/database_tests/query_test.py
@@ -13,21 +13,21 @@ class QueryTestCase(unittest.TestCase):
         self.db.create_schema()
 
     def test_it_inserts_records(self):
-        data = {'title': 'My title', 'body': 'My body', 'created_by': self.db.create_user()['id']}
+        data = {'title': 'My title', 'body': 'My body', 'created_by': self.db.create_user().get('id')}
         record = self.query.insert(data)
         self.assertDictContainsSubset(data, record)
 
     def test_it_updates_records(self):
         self.db.create_entry(3)
         data = {'title': 'Updated title', 'body': 'Updated body'}
-        updated = self.query.update(data, {'id': self.db.random_entry()['id']})
+        updated = self.query.update(data, {'id': self.db.random_entry().get('id')})
         self.assertDictContainsSubset(data, updated)
 
     def test_it_deletes_records(self):
         self.db.create_entry()
         record = self.db.random_entry()
-        self.query.delete({'id': record['id']})
-        self.assertEqual([], self.query.select('*', {'id': record['id']}))
+        self.query.delete({'id': record.get('id')})
+        self.assertEqual([], self.query.select('*', {'id': record.get('id')}))
 
     def test_it_gets_count_of_records(self):
         self.assertEqual(0, self.query.count())
@@ -36,11 +36,11 @@ class QueryTestCase(unittest.TestCase):
 
     def test_updated_at_column_is_updated(self):
         self.db.create_entry(3)
-        record = self.query.select('*', {'id': self.db.random_entry()['id']})[0]
+        record = self.query.select('*', {'id': self.db.random_entry().get('id')})[0]
         sleep(0.5)  # delay for 500ms before update
-        self.query.update({'title': 'Tile', 'body': 'Body'}, {'id': record['id']})
-        updated = self.query.select('*', {'id': record['id']})[0]
-        self.assertGreater(updated['updated_at'], record['updated_at'])
+        self.query.update({'title': 'Tile', 'body': 'Body'}, {'id': record.get('id')})
+        updated = self.query.select('*', {'id': record.get('id')})[0]
+        self.assertGreater(updated.get('updated_at'), record.get('updated_at'))
 
     def tearDown(self):
         self.db.drop_schema()

--- a/tests/entry_api_tests/base_test.py
+++ b/tests/entry_api_tests/base_test.py
@@ -11,9 +11,9 @@ class BaseTestCase(unittest.TestCase):
         self.fake = Faker()
         self.db = DBUtils()
         self.db.create_schema()
-        self.client = app.test_client(self)
         user = self.db.create_user()
-        self.user_id = user['id']
+        self.user_id = user.get('id')
+        self.client = app.test_client(self)
         self.token = User.generate_token(user)
 
     def get(self, url):

--- a/tests/entry_api_tests/base_test.py
+++ b/tests/entry_api_tests/base_test.py
@@ -1,7 +1,8 @@
 import unittest
 from faker import Faker
 from app import app
-from tests.helpers import DBUtils, auth_token
+from tests.helpers import DBUtils
+from app.models import User
 
 
 class BaseTestCase(unittest.TestCase):
@@ -11,7 +12,9 @@ class BaseTestCase(unittest.TestCase):
         self.db = DBUtils()
         self.db.create_schema()
         self.client = app.test_client(self)
-        self.token = auth_token()
+        user = self.db.create_user()
+        self.user_id = user['id']
+        self.token = User.generate_token(user)
 
     def get(self, url):
         return self.client.get(url, headers={'x-access-token': self.token})

--- a/tests/entry_api_tests/create_test.py
+++ b/tests/entry_api_tests/create_test.py
@@ -9,7 +9,7 @@ class CreateTestCase(BaseTestCase):
         response = self.post('/api/v1/entries', data=new_entry)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.mimetype, 'application/json')
-        self.assertDictContainsSubset(new_entry, json.loads(response.data)['entry'])
+        self.assertDictContainsSubset(new_entry, json.loads(response.data).get('entry'))
 
     def test_fails_when_data_does_not_meet_min_length(self):
         short_data = {'title': 'Cook', 'body': 'Short'}
@@ -20,7 +20,7 @@ class CreateTestCase(BaseTestCase):
             'title': ['The title field must have a minimum length of 5.'],
             'body': ['The body field must have a minimum length of 10.'],
         }
-        self.assertEqual(errors, json.loads(response.data)['errors'])
+        self.assertEqual(errors, json.loads(response.data).get('errors'))
 
     def test_fails_when_data_exceeds_max_length(self):
         long_text = self.fake.text(1000)
@@ -32,7 +32,7 @@ class CreateTestCase(BaseTestCase):
             'title': ['The title field must have a maximum length of 255.'],
             'body': ['The body field must have a maximum length of 1000.'],
         }
-        self.assertEqual(errors, json.loads(response.data)['errors'])
+        self.assertEqual(errors, json.loads(response.data).get('errors'))
 
     def test_fails_when_data_is_missing(self):
         response = self.post('/api/v1/entries', data={})
@@ -42,4 +42,4 @@ class CreateTestCase(BaseTestCase):
             'title': ['The title field is required.'],
             'body': ['The body field is required.'],
         }
-        self.assertEqual(errors, json.loads(response.data)['errors'])
+        self.assertEqual(errors, json.loads(response.data).get('errors'))

--- a/tests/entry_api_tests/delete_test.py
+++ b/tests/entry_api_tests/delete_test.py
@@ -6,13 +6,13 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class DeleteTestCase(BaseTestCase):
 
     def test_it_deletes_entries(self):
-        entry_id = self.db.create_entry(overrides={'created_by': self.user_id})['id']
+        entry_id = self.db.create_entry(overrides={'created_by': self.user_id}).get('id')
         response = self.delete('/api/v1/entries/%s' % str(entry_id))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
         self.assertEqual({'message': 'Entry deleted.'}, json.loads(response.data))
-        all_entries = json.loads(self.get('/api/v1/entries').data)['entries']
-        self.assertFalse(any(entry['id'] == entry_id for entry in all_entries))
+        all_entries = json.loads(self.get('/api/v1/entries').data).get('entries')
+        self.assertFalse(any(entry.get('id') == entry_id for entry in all_entries))
 
     def test_if_fails_when_the_current_user_is_not_the_owner(self):
         entry_id = self.db.create_entry().get('id')

--- a/tests/entry_api_tests/delete_test.py
+++ b/tests/entry_api_tests/delete_test.py
@@ -6,7 +6,7 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class DeleteTestCase(BaseTestCase):
 
     def test_it_deletes_entries(self):
-        entry_id = self.db.create_entry()['id']
+        entry_id = self.db.create_entry(overrides={'created_by': self.user_id})['id']
         response = self.delete('/api/v1/entries/%s' % str(entry_id))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')

--- a/tests/entry_api_tests/delete_test.py
+++ b/tests/entry_api_tests/delete_test.py
@@ -14,6 +14,11 @@ class DeleteTestCase(BaseTestCase):
         all_entries = json.loads(self.get('/api/v1/entries').data)['entries']
         self.assertFalse(any(entry['id'] == entry_id for entry in all_entries))
 
+    def test_if_fails_when_the_current_user_is_not_the_owner(self):
+        entry_id = self.db.create_entry().get('id')
+        response = self.delete('/api/v1/entries/%s' % str(entry_id))
+        self.assertEqual(response.status_code, 404)
+
     def test_fails_on_model_not_found(self):
         response = self.delete('/api/v1/entries/71115')
         self.assertEqual(response.status_code, 404)

--- a/tests/entry_api_tests/get_test.py
+++ b/tests/entry_api_tests/get_test.py
@@ -5,7 +5,7 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class GetTestCase(BaseTestCase):
 
     def test_it_gets_a_specific_entry(self):
-        record = self.db.create_entry()
+        record = self.db.create_entry(overrides={'created_by': self.user_id})
         response = self.get('/api/v1/entries/%s' % str(record['id']))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')

--- a/tests/entry_api_tests/get_test.py
+++ b/tests/entry_api_tests/get_test.py
@@ -11,3 +11,8 @@ class GetTestCase(BaseTestCase):
         self.assertEqual(response.mimetype, 'application/json')
         expected_data = {'title': record['title'], 'body': record['body']}
         self.assertDictContainsSubset(expected_data, json.loads(response.data)['entry'])
+
+    def test_if_fails_when_the_current_user_is_not_the_owner(self):
+        entry_id = self.db.create_entry().get('id')
+        response = self.delete('/api/v1/entries/%s' % str(entry_id))
+        self.assertEqual(response.status_code, 404)

--- a/tests/entry_api_tests/get_test.py
+++ b/tests/entry_api_tests/get_test.py
@@ -6,11 +6,11 @@ class GetTestCase(BaseTestCase):
 
     def test_it_gets_a_specific_entry(self):
         record = self.db.create_entry(overrides={'created_by': self.user_id})
-        response = self.get('/api/v1/entries/%s' % str(record['id']))
+        response = self.get('/api/v1/entries/%s' % str(record.get('id')))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
-        expected_data = {'title': record['title'], 'body': record['body']}
-        self.assertDictContainsSubset(expected_data, json.loads(response.data)['entry'])
+        expected_data = {'title': record.get('title'), 'body': record.get('body')}
+        self.assertDictContainsSubset(expected_data, json.loads(response.data).get('entry'))
 
     def test_if_fails_when_the_current_user_is_not_the_owner(self):
         entry_id = self.db.create_entry().get('id')

--- a/tests/entry_api_tests/list_test.py
+++ b/tests/entry_api_tests/list_test.py
@@ -9,8 +9,12 @@ class ListTestCase(BaseTestCase):
         response = self.get('/api/v1/entries')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
-        expected = [{'title': item['title'], 'body': item['body']} for item in records]
-        received = [{'title': item['title'], 'body': item['body']} for item in json.loads(response.data)['entries']]
+        expected = [
+            {'title': item.get('title'), 'body': item.get('body')} for item in records
+        ]
+        received = [
+            {'title': item.get('title'), 'body': item.get('body')} for item in json.loads(response.data).get('entries')
+        ]
         self.assertEqual(expected, received)
 
     def test_it_only_returns_entries_for_the_owner(self):

--- a/tests/entry_api_tests/list_test.py
+++ b/tests/entry_api_tests/list_test.py
@@ -12,3 +12,8 @@ class ListTestCase(BaseTestCase):
         expected = [{'title': item['title'], 'body': item['body']} for item in records]
         received = [{'title': item['title'], 'body': item['body']} for item in json.loads(response.data)['entries']]
         self.assertEqual(expected, received)
+
+    def test_it_only_returns_entries_for_the_owner(self):
+        self.db.create_entry(3)
+        response = self.get('/api/v1/entries')
+        self.assertEqual(0, json.loads(response.data).get('count'))

--- a/tests/entry_api_tests/list_test.py
+++ b/tests/entry_api_tests/list_test.py
@@ -5,7 +5,7 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class ListTestCase(BaseTestCase):
 
     def test_it_lists_all_entries(self):
-        records = self.db.create_entry(3)
+        records = self.db.create_entry(count=3, overrides={'created_by': self.user_id})
         response = self.get('/api/v1/entries')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')

--- a/tests/entry_api_tests/stats_test.py
+++ b/tests/entry_api_tests/stats_test.py
@@ -19,7 +19,7 @@ class StatsTestCase(BaseTestCase):
         self.assertEqual(new_count, old_count + 1)
 
     def test_entry_count_remains_accurate_after_deletion(self):
-        self.db.create_entry(4)
+        self.db.create_entry(count=4, overrides={'created_by': self.user_id})
         old_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']
         self.delete('/api/v1/entries/2')
         new_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']

--- a/tests/entry_api_tests/stats_test.py
+++ b/tests/entry_api_tests/stats_test.py
@@ -5,11 +5,16 @@ from tests.entry_api_tests.base_test import BaseTestCase
 class StatsTestCase(BaseTestCase):
 
     def test_it_gets_entry_count_stat(self):
-        self.db.create_entry(3)
+        self.db.create_entry(count=3, overrides={'created_by': self.user_id})
         response = self.get('/api/v1/entries/stats/count')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
         self.assertEqual(3, json.loads(response.data)['count'])
+
+    def test_it_gets_entry_count_only_for_owner(self):
+        self.db.create_entry(3)
+        response = self.get('/api/v1/entries/stats/count')
+        self.assertEqual(0, json.loads(response.data).get('count'))
 
     def test_entry_count_remains_accurate_after_creation(self):
         data = {'title': 'A title', 'body': 'This is a body'}

--- a/tests/entry_api_tests/stats_test.py
+++ b/tests/entry_api_tests/stats_test.py
@@ -9,7 +9,7 @@ class StatsTestCase(BaseTestCase):
         response = self.get('/api/v1/entries/stats/count')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
-        self.assertEqual(3, json.loads(response.data)['count'])
+        self.assertEqual(3, json.loads(response.data).get('count'))
 
     def test_it_gets_entry_count_only_for_owner(self):
         self.db.create_entry(3)
@@ -18,14 +18,14 @@ class StatsTestCase(BaseTestCase):
 
     def test_entry_count_remains_accurate_after_creation(self):
         data = {'title': 'A title', 'body': 'This is a body'}
-        old_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']
+        old_count = json.loads(self.get('/api/v1/entries/stats/count').data).get('count')
         self.post('/api/v1/entries', data=data)
-        new_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']
+        new_count = json.loads(self.get('/api/v1/entries/stats/count').data).get('count')
         self.assertEqual(new_count, old_count + 1)
 
     def test_entry_count_remains_accurate_after_deletion(self):
         self.db.create_entry(count=4, overrides={'created_by': self.user_id})
-        old_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']
+        old_count = json.loads(self.get('/api/v1/entries/stats/count').data).get('count')
         self.delete('/api/v1/entries/2')
-        new_count = json.loads(self.get('/api/v1/entries/stats/count').data)['count']
+        new_count = json.loads(self.get('/api/v1/entries/stats/count').data).get('count')
         self.assertEqual(new_count, old_count - 1)

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -11,7 +11,7 @@ class UpdateTestCase(BaseTestCase):
         response = self.put('/api/v1/entries/2', data=updates)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
-        self.assertDictContainsSubset(updates, json.loads(response.data)['entry'])
+        self.assertDictContainsSubset(updates, json.loads(response.data).get('entry'))
 
     def test_it_only_updates_entries_for_owner(self):
         self.db.create_entry(count=3)
@@ -34,7 +34,7 @@ class UpdateTestCase(BaseTestCase):
             'title': ['The title field must have a minimum length of 5.'],
             'body': ['The body field must have a minimum length of 10.'],
         }
-        self.assertEqual(errors, json.loads(response.data)['errors'])
+        self.assertEqual(errors, json.loads(response.data).get('errors'))
 
     def test_fails_when_data_exceeds_max_length(self):
         long_text = self.fake.text(1000)
@@ -46,7 +46,7 @@ class UpdateTestCase(BaseTestCase):
             'title': ['The title field must have a maximum length of 255.'],
             'body': ['The body field must have a maximum length of 1000.'],
         }
-        self.assertEqual(errors, json.loads(response.data)['errors'])
+        self.assertEqual(errors, json.loads(response.data).get('errors'))
 
     def test_fails_when_data_is_missing(self):
         response = self.put('/api/v1/entries/4', data={})
@@ -56,4 +56,4 @@ class UpdateTestCase(BaseTestCase):
             'title': ['The title field is required.'],
             'body': ['The body field is required.'],
         }
-        self.assertEqual(errors, json.loads(response.data)['errors'])
+        self.assertEqual(errors, json.loads(response.data).get('errors'))

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -4,6 +4,7 @@ from tests.entry_api_tests.base_test import BaseTestCase
 
 
 class UpdateTestCase(BaseTestCase):
+
     def test_it_updates_entries(self):
         self.db.create_entry(count=3, overrides={'created_by': self.user_id})
         updates = {'title': 'A new title', 'body': 'A new body'}
@@ -11,6 +12,12 @@ class UpdateTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, 'application/json')
         self.assertDictContainsSubset(updates, json.loads(response.data)['entry'])
+
+    def test_it_only_updates_entries_for_owner(self):
+        self.db.create_entry(count=3)
+        updates = {'title': 'A new title', 'body': 'A new body'}
+        response = self.put('/api/v1/entries/2', data=updates)
+        self.assertEqual(response.status_code, 404)
 
     def test_fails_on_model_not_found(self):
         response = self.delete('/api/v1/entries/81115')

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -5,7 +5,7 @@ from tests.entry_api_tests.base_test import BaseTestCase
 
 class UpdateTestCase(BaseTestCase):
     def test_it_updates_entries(self):
-        self.db.create_entry(3)
+        self.db.create_entry(count=3, overrides={'created_by': self.user_id})
         updates = {'title': 'A new title', 'body': 'A new body'}
         response = self.put('/api/v1/entries/2', data=updates)
         self.assertEqual(response.status_code, 200)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -48,9 +48,9 @@ class DBUtils:
         for i in range(0, count):
             users.append(
                 {
-                    'name': overrides['name'] if 'name' in override_fields else self.fake.name(),
-                    'email': overrides['email'] if 'email' in override_fields else self.fake.email(),
-                    'password': overrides['password'] if 'password' in override_fields else self.fake.password()
+                    'name': overrides.get('name') if 'name' in override_fields else self.fake.name(),
+                    'email': overrides.get('email') if 'email' in override_fields else self.fake.email(),
+                    'password': overrides.get('password') if 'password' in override_fields else self.fake.password()
                 }
             )
         return users[0] if count == 1 else users
@@ -68,9 +68,10 @@ class DBUtils:
         entries = []
         for i in range(0, count):
             entries.append({
-                'title': overrides['title'] if 'title' in override_fields else self.fake.name(),
-                'body': overrides['body'] if 'body' in override_fields else self.fake.email(),
-                'created_by': overrides['created_by'] if 'created_by' in override_fields else self.create_user()['id']
+                'title': overrides.get('title') if 'title' in override_fields else self.fake.name(),
+                'body': overrides.get('body') if 'body' in override_fields else self.fake.email(),
+                'created_by':
+                    overrides.get('created_by') if 'created_by' in override_fields else self.create_user().get('id')
             })
         return entries[0] if count == 1 else entries
 
@@ -119,7 +120,7 @@ class DBUtils:
             # insert item
             self.cursor.execute(query, random_values)
             # get id of inserted item
-            item_ids.append(self.cursor.fetchone()['id'])
+            item_ids.append(self.cursor.fetchone().get('id'))
         # build query to retrieve just inserted item
         query = sql.SQL("select * from {} where id in ({})").format(
             sql.Identifier(table),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -128,8 +128,3 @@ class DBUtils:
         # retrieve just inserted items
         self.cursor.execute(query, item_ids)
         return self.cursor.fetchone() if count == 1 else self.cursor.fetchall()
-
-
-def auth_token():
-    user = User.create('Mutai Mwiti', 'mutaimwiti40@gmail.com', 'secret')
-    return User.generate_token(user)

--- a/tests/model_tests/entry_test.py
+++ b/tests/model_tests/entry_test.py
@@ -15,7 +15,7 @@ class EntryModelTestCase(unittest.TestCase):
     def test_it_gets_a_specific_entry(self):
         self.db.create_entry(4)
         entry = self.db.random_entry()
-        self.assertEqual(entry, Entry.get({'id': entry['id']}))
+        self.assertEqual(entry, Entry.get({'id': entry.get('id')}))
         # Fails for non-existent entries
         with self.assertRaises(ModelNotFoundException):
             Entry.get({'id': 51115})
@@ -23,7 +23,7 @@ class EntryModelTestCase(unittest.TestCase):
     def test_it_creates_new_entries(self):
         title = 'A title'
         body = 'A body'
-        new_entry = Entry.create(title, body, self.db.create_user()['id'])
+        new_entry = Entry.create(title, body, self.db.create_user().get('id'))
         self.assertDictContainsSubset({'title': title, 'body': body}, new_entry)
 
     def test_it_updates_entries(self):
@@ -52,7 +52,7 @@ class EntryModelTestCase(unittest.TestCase):
         self.db.create_entry(5)
         # when new entry is created
         count_before = Entry.count()
-        Entry.create('A title', 'A body', self.db.create_user()['id'])
+        Entry.create('A title', 'A body', self.db.create_user().get('id'))
         count_after = Entry.count()
         self.assertEqual(count_after, count_before + 1)
         # when an entry is deleted

--- a/tests/model_tests/entry_test.py
+++ b/tests/model_tests/entry_test.py
@@ -15,10 +15,10 @@ class EntryModelTestCase(unittest.TestCase):
     def test_it_gets_a_specific_entry(self):
         self.db.create_entry(4)
         entry = self.db.random_entry()
-        self.assertEqual(entry, Entry.get(entry['id']))
+        self.assertEqual(entry, Entry.get({'id': entry['id']}))
         # Fails for non-existent entries
         with self.assertRaises(ModelNotFoundException):
-            Entry.get(51115)
+            Entry.get({'id': 51115})
 
     def test_it_creates_new_entries(self):
         title = 'A title'
@@ -30,19 +30,19 @@ class EntryModelTestCase(unittest.TestCase):
         self.db.create_entry(10)
         title = 'A new title'
         body = 'A new body'
-        updated_entry = Entry.update(2, title, body)
-        self.assertEqual(updated_entry, Entry.get(2))
+        updated_entry = Entry.update({'id': 2}, title, body)
+        self.assertEqual(updated_entry, Entry.get({'id': 2}))
         self.assertDictContainsSubset({'title': title, 'body': body}, updated_entry)
         # Fails for non-existent entries
         with self.assertRaises(ModelNotFoundException):
-            Entry.update(71115, 'Foo', 'Bar')
+            Entry.update({'id': 71115}, 'Foo', 'Bar')
 
     def test_it_deletes_entries(self):
         self.db.create_entry(4)
-        self.assertTrue(Entry.delete(3))
+        self.assertTrue(Entry.delete({'id': 3}))
         # Fails for non-existent entries
         with self.assertRaises(ModelNotFoundException):
-            Entry.delete(91155)
+            Entry.delete({'id': 91155})
 
     def test_it_gets_entry_count(self):
         self.db.create_entry(6)
@@ -57,7 +57,7 @@ class EntryModelTestCase(unittest.TestCase):
         self.assertEqual(count_after, count_before + 1)
         # when an entry is deleted
         count_before = Entry.count()
-        Entry.delete(2)
+        Entry.delete({'id': 2})
         count_after = Entry.count()
         self.assertEqual(count_after, count_before - 1)
 


### PR DESCRIPTION
This PR delivers filters of entries by their owner.

Filtering is achieved by filtering queries(`created_at`) against the currently authenticated user.