### PR TITLE
Allow trailing slashes on API endpoints

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -10,50 +10,50 @@ app = Flask(__name__)
 
 # Define API endpoints
 # Entry resource routes
-@app.route('/api/v1/entries')
+@app.route('/api/v1/entries/', strict_slashes=False)
 @UserController.check_auth
 def all_entries():
     return EntryController.all()
 
 
-@app.route('/api/v1/entries/<int:entry_id>')
+@app.route('/api/v1/entries/<int:entry_id>/', strict_slashes=False)
 @UserController.check_auth
 def get(entry_id):
     return EntryController.get(entry_id)
 
 
-@app.route('/api/v1/entries', methods=['POST'])
+@app.route('/api/v1/entries/', methods=['POST'], strict_slashes=False)
 @UserController.check_auth
 def create():
     return EntryController.create()
 
 
-@app.route('/api/v1/entries/<int:entry_id>', methods=['PUT'])
+@app.route('/api/v1/entries/<int:entry_id>/', methods=['PUT'], strict_slashes=False)
 @UserController.check_auth
 def update(entry_id):
     return EntryController.update(entry_id)
 
 
-@app.route('/api/v1/entries/<int:entry_id>', methods=['DELETE'])
+@app.route('/api/v1/entries/<int:entry_id>/', methods=['DELETE'], strict_slashes=False)
 @UserController.check_auth
 def delete(entry_id):
     return EntryController.delete(entry_id)
 
 
 # Entry stats routes
-@app.route('/api/v1/entries/stats/count', methods=['GET'])
+@app.route('/api/v1/entries/stats/count/', methods=['GET'], strict_slashes=False)
 @UserController.check_auth
 def entry_stat_count():
     return EntryController.count()
 
 
 # User routes
-@app.route('/api/v1/signup', methods=['POST'])
+@app.route('/api/v1/signup/', methods=['POST'], strict_slashes=False)
 def signup():
     return UserController.signup()
 
 
-@app.route('/api/v1/login')
+@app.route('/api/v1/login/', strict_slashes=False)
 def login():
     return UserController.login()
 

--- a/tests/entry_api_tests/create_test.py
+++ b/tests/entry_api_tests/create_test.py
@@ -11,6 +11,10 @@ class CreateTestCase(BaseTestCase):
         self.assertEqual(response.mimetype, 'application/json')
         self.assertDictContainsSubset(new_entry, json.loads(response.data).get('entry'))
 
+    def test_it_allows_trailing_trash(self):
+        response = self.post('/api/v1/entries/', data={'title': 'A title', 'body': 'A body to add'})
+        self.assertEqual(response.status_code, 201)
+
     def test_fails_when_data_does_not_meet_min_length(self):
         short_data = {'title': 'Cook', 'body': 'Short'}
         response = self.post('/api/v1/entries', data=short_data)

--- a/tests/entry_api_tests/delete_test.py
+++ b/tests/entry_api_tests/delete_test.py
@@ -14,6 +14,11 @@ class DeleteTestCase(BaseTestCase):
         all_entries = json.loads(self.get('/api/v1/entries').data).get('entries')
         self.assertFalse(any(entry.get('id') == entry_id for entry in all_entries))
 
+    def test_it_allows_trailing_trash(self):
+        entry = self.db.create_entry(overrides={'created_by': self.user_id})
+        response = self.delete('/api/v1/entries/%s/' % str(entry.get('id')))
+        self.assertEqual(response.status_code, 200)
+
     def test_if_fails_when_the_current_user_is_not_the_owner(self):
         entry_id = self.db.create_entry().get('id')
         response = self.delete('/api/v1/entries/%s' % str(entry_id))

--- a/tests/entry_api_tests/get_test.py
+++ b/tests/entry_api_tests/get_test.py
@@ -12,6 +12,11 @@ class GetTestCase(BaseTestCase):
         expected_data = {'title': record.get('title'), 'body': record.get('body')}
         self.assertDictContainsSubset(expected_data, json.loads(response.data).get('entry'))
 
+    def test_it_allows_trailing_trash(self):
+        record = self.db.create_entry(overrides={'created_by': self.user_id})
+        response = self.get('/api/v1/entries/%s/' % str(record.get('id')))
+        self.assertEqual(response.status_code, 200)
+
     def test_if_fails_when_the_current_user_is_not_the_owner(self):
         entry_id = self.db.create_entry().get('id')
         response = self.delete('/api/v1/entries/%s' % str(entry_id))

--- a/tests/entry_api_tests/global_test.py
+++ b/tests/entry_api_tests/global_test.py
@@ -6,7 +6,7 @@ class GlobalTestCase(BaseTestCase):
     def test_invalid_urls_trigger_not_found(self):
         responses = []
         data = {'title': 'A title', 'body': 'A body'}
-        urls = ['/gibberish', '/api/v1/entries/', '/api/v1/entries/x']
+        urls = ['/foo', '/api/v1/foo', '/api/v1/entries/foo']
         for url in urls:
             responses.append(self.get(url))
             responses.append(self.post(url, data=data))

--- a/tests/entry_api_tests/list_test.py
+++ b/tests/entry_api_tests/list_test.py
@@ -17,6 +17,11 @@ class ListTestCase(BaseTestCase):
         ]
         self.assertEqual(expected, received)
 
+    def test_it_allows_trailing_trash(self):
+        self.db.create_entry(count=3, overrides={'created_by': self.user_id})
+        response = self.get('/api/v1/entries/')
+        self.assertEqual(response.status_code, 200)
+
     def test_it_only_returns_entries_for_the_owner(self):
         self.db.create_entry(3)
         response = self.get('/api/v1/entries')

--- a/tests/entry_api_tests/stats_test.py
+++ b/tests/entry_api_tests/stats_test.py
@@ -11,6 +11,11 @@ class StatsTestCase(BaseTestCase):
         self.assertEqual(response.mimetype, 'application/json')
         self.assertEqual(3, json.loads(response.data).get('count'))
 
+    def test_it_allows_trailing_trash(self):
+        self.db.create_entry(count=3, overrides={'created_by': self.user_id})
+        response = self.get('/api/v1/entries/stats/count/')
+        self.assertEqual(response.status_code, 200)
+
     def test_it_gets_entry_count_only_for_owner(self):
         self.db.create_entry(3)
         response = self.get('/api/v1/entries/stats/count')

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -13,6 +13,11 @@ class UpdateTestCase(BaseTestCase):
         self.assertEqual(response.mimetype, 'application/json')
         self.assertDictContainsSubset(updates, json.loads(response.data).get('entry'))
 
+    def test_it_allows_trailing_trash(self):
+        self.db.create_entry(count=3, overrides={'created_by': self.user_id})
+        response = self.put('/api/v1/entries/2/', data={'title': 'A new title', 'body': 'A new body'})
+        self.assertEqual(response.status_code, 200)
+
     def test_it_only_updates_entries_for_owner(self):
         self.db.create_entry(count=3)
         updates = {'title': 'A new title', 'body': 'A new body'}


### PR DESCRIPTION
This PR delivers support for trailing trashes on endpoints. It is now possible to access them as follows:
1. `GET /api/v1/entries/`
2. `GET /api/v1/entries/<entryId>/`
3. `POST /api/v1/entries/`
4. `PUT /api/v1/entries/<entryId>/`
5. `DELETE /api/v1/entries/<entryId>/`
6. `GET /api/v1/entries/stats/count/`
7. `POST /api/v1/signup/`
8. `GET /api/v1/login/`

Manual testing can be done using Postman.
