### PR TITLE
Enable trailing slash on endpoints

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -28,14 +28,21 @@ class EntryController:
     @staticmethod
     def create():
         validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
-        entry = Entry.create(request.form.get('title'), request.form.get('body'), auth.id())
-        if not entry:
+        title = request.form.get('title')
+        body = request.form.get('body')
+        auth_id = auth.id()
+        if Entry.exists({'title': title, 'body': body, 'created_by': auth_id}):
             return jsonify({'message': 'A similar already entry exists.'}), 409
-        return jsonify({'entry': entry}), 201
+        return jsonify({'entry': Entry.create(title, body, auth_id)}), 201
 
     @staticmethod
     def update(entry_id):
         validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
+        title = request.form.get('title')
+        body = request.form.get('body')
+        auth_id = auth.id()
+        if Entry.exists({'title': title, 'body': body, 'created_by': auth_id}):
+            return jsonify({'message': 'A similar already entry exists.'}), 409
         entry = Entry.update(
             {'id': entry_id, 'created_by': auth.id()},
             request.form.get('title'),

--- a/app/controllers.py
+++ b/app/controllers.py
@@ -29,6 +29,8 @@ class EntryController:
     def create():
         validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
         entry = Entry.create(request.form.get('title'), request.form.get('body'), auth.id())
+        if not entry:
+            return jsonify({'message': 'A similar already entry exists.'}), 409
         return jsonify({'entry': entry}), 201
 
     @staticmethod

--- a/app/models.py
+++ b/app/models.py
@@ -17,8 +17,12 @@ class Entry:
 
     @staticmethod
     def __check(filters):
-        if Entry.__db.exists(filters) is False:
+        if Entry.exists(filters) is False:
             raise ModelNotFoundException
+        
+    @staticmethod    
+    def exists(filters):
+        return Entry.__db.exists(filters)
 
     @staticmethod
     def count(filters=None):

--- a/app/models.py
+++ b/app/models.py
@@ -48,6 +48,8 @@ class Entry:
         Creates an entry and returns a copy.
         :rtype: dict
         """
+        if Entry.__db.exists({'title': title, 'body': body, 'created_by': created_by}):
+            return None
         return Entry.__db.insert({
             'title': title,
             'body': body,

--- a/tests/entry_api_tests/create_test.py
+++ b/tests/entry_api_tests/create_test.py
@@ -47,3 +47,10 @@ class CreateTestCase(BaseTestCase):
             'body': ['The body field is required.'],
         }
         self.assertEqual(errors, json.loads(response.data).get('errors'))
+
+    def test_it_fails_when_a_similar_entry_exists_for_owner(self):
+        data = {'title': 'A title', 'body': 'An entry body', 'created_by': self.user_id}
+        self.db.create_entry(overrides=data)
+        response = self.post('/api/v1/entries', data=data)
+        self.assertEqual(409, response.status_code)
+        self.assertEqual('A similar already entry exists.', json.loads(response.data).get('message'))

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -62,3 +62,10 @@ class UpdateTestCase(BaseTestCase):
             'body': ['The body field is required.'],
         }
         self.assertEqual(errors, json.loads(response.data).get('errors'))
+
+    def test_fails_when_a_similar_entry_exists_for_owner(self):
+        data = {'title': 'A title', 'body': 'An entry body', 'created_by': self.user_id}
+        entry = self.db.create_entry(overrides=data)
+        response = self.put('/api/v1/entries/%s' % entry.get('id'), data=data)
+        self.assertEqual(409, response.status_code)
+        self.assertEqual('A similar already entry exists.', json.loads(response.data).get('message'))


### PR DESCRIPTION
This PR delivers functionality to reject the creation of duplicate entries.
This affects the creation and update of entries.
1. `POST /api/v1/entries/`
2. `PUT /api/v1/entries/<entryId>/`

Manual testing can be done using Postman.
