### PR TITLE
Trim all input fields

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -27,9 +27,9 @@ class EntryController:
 
     @staticmethod
     def create():
-        validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
-        title = request.form.get('title')
-        body = request.form.get('body')
+        values = validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
+        title = values.get('title')
+        body = values.get('body')
         auth_id = auth.id()
         if Entry.exists({'title': title, 'body': body, 'created_by': auth_id}):
             return jsonify({'message': 'A similar already entry exists.'}), 409
@@ -37,17 +37,13 @@ class EntryController:
 
     @staticmethod
     def update(entry_id):
-        validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
-        title = request.form.get('title')
-        body = request.form.get('body')
+        values = validate(request.form, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
+        title = values.get('title')
+        body = values.get('body')
         auth_id = auth.id()
         if Entry.exists({'title': title, 'body': body, 'created_by': auth_id}):
             return jsonify({'message': 'A similar already entry exists.'}), 409
-        entry = Entry.update(
-            {'id': entry_id, 'created_by': auth.id()},
-            request.form.get('title'),
-            request.form.get('body')
-        )
+        entry = Entry.update({'id': entry_id, 'created_by': auth_id}, title, body)
         return jsonify({'entry': entry}), 200
 
     @staticmethod
@@ -63,8 +59,8 @@ class UserController:
     @staticmethod
     def signup():
         # create a new user
-        validate(request.form, {'name': 'required', 'email': 'required|email', 'password': 'required|min:6'})
-        created = User.create(request.form.get('name'), request.form.get('email'), request.form.get('password'))
+        values = validate(request.form, {'name': 'required', 'email': 'required|email', 'password': 'required|min:6'})
+        created = User.create(values.get('name'), values.get('email'), values.get('password'))
         if created is False:
             return jsonify({'message': 'A user with the same email address exists.'}), 409
         return jsonify({'message': 'User created.'}), 201

--- a/app/request.py
+++ b/app/request.py
@@ -137,7 +137,8 @@ class Validator:
         """
         if field not in self.request:
             return None
-        return self.request[field]
+        field_value = self.request[field]
+        return str(field_value).strip() if type(field_value) is str else field_value
 
     def rules(self, field):
         """
@@ -174,10 +175,12 @@ class Validator:
         return self.value(field) is not None
 
     def validate(self):
+        values = {}  # stores trimmed values for all fields
         all_errors = {}  # stores all validation errors found
         for field in self.fields():
             errors = []  # stores validation errors for current field
             if self.is_set(field):
+                values.update({field: self.value(field)})
                 # current field is set
                 # get value of field on request
                 for rule in self.rules(field):
@@ -212,7 +215,7 @@ class Validator:
         if len(all_errors) > 0:
             # an error or errors were found in any of the fields
             raise ValidationException({'errors': all_errors})
-        return True
+        return values
 
 
 def validate(request, rules):

--- a/tests/validator_tests/base_test.py
+++ b/tests/validator_tests/base_test.py
@@ -19,13 +19,13 @@ class BaseTestCase(unittest.TestCase):
     def test_empty_rule_string_works(self):
         request = {'test_field': 'Some value'}
         rules = {'test_field': ''}
-        self.assertTrue(validate(request, rules))
+        self.assertEqual(request, validate(request, rules))
 
     def test_many_fields_can_be_validated(self):
         # without errors
         request = {'test_field': 'Some value', 'test_field2': 'Some other value'}
         rules = {'test_field': 'required', 'test_field2': 'min:5'}
-        self.assertTrue(validate(request, rules))
+        self.assertEqual(request, validate(request, rules))
         # with errors
         request = {'test_field': 'Some value', 'test_field2': 'Some other value'}
         rules = {'test_field': 'max:5', 'test_field2': 'min:20'}
@@ -52,3 +52,15 @@ class BaseTestCase(unittest.TestCase):
         with self.assertRaises(InvalidValidatorException) as context:
             validate(request, rules)
         self.assertTrue('Rule [min:5:17] has so more than one argument.' in str(context.exception))
+
+    def test_it_trims_input(self):
+        request = {
+            'test_field': '  Some value with whitespaces   ',
+            'test_field2': '    Some other value with whitespaces  '
+        }
+        rules = {'test_field': 'required|min:20', 'test_field2': 'required|max:100'}
+        expected = {
+            'test_field': 'Some value with whitespaces',
+            'test_field2': 'Some other value with whitespaces'
+        }
+        self.assertEquals(expected, validate(request, rules))

--- a/tests/validator_tests/max_rule_test.py
+++ b/tests/validator_tests/max_rule_test.py
@@ -12,11 +12,11 @@ class MaxRuleTestCase(unittest.TestCase):
         # less than max
         request = {'test_field': 'Less than 15'}
         rules = {'test_field': 'max:15'}
-        self.assertEqual(validate(request, rules), True)
+        self.assertEqual(request, validate(request, rules), True)
         # equal to max
         request = {'test_field': 'Equal 2 fifteen'}
         rules = {'test_field': 'max:15'}
-        self.assertEqual(validate(request, rules), True)
+        self.assertEqual(request, validate(request, rules))
 
     def test_fails_if_field_length_is_less_than_max(self):
         """

--- a/tests/validator_tests/min_rule_test.py
+++ b/tests/validator_tests/min_rule_test.py
@@ -12,11 +12,11 @@ class MinRuleTestCase(unittest.TestCase):
         # greater than min
         request = {'test_field': 'Greater than fifteen'}
         rules = {'test_field': 'min:15'}
-        self.assertEqual(validate(request, rules), True)
+        self.assertEqual(request, validate(request, rules), True)
         # equal to min
         request = {'test_field': 'Equal 2 fifteen'}
         rules = {'test_field': 'min:15'}
-        self.assertEqual(validate(request, rules), True)
+        self.assertEqual(request, validate(request, rules), True)
 
     def test_fails_if_field_length_is_less_than_min(self):
         """

--- a/tests/validator_tests/required_rule_test.py
+++ b/tests/validator_tests/required_rule_test.py
@@ -20,7 +20,7 @@ class RequiredRuleTestCase(unittest.TestCase):
         """
         request = {'test_field': 'Some value'}
         rules = {'test_field': 'required'}
-        self.assertEqual(validate(request, rules), True)
+        self.assertEqual(request, validate(request, rules))
 
     def test_required_fails_if_field_is_not_set(self):
         """


### PR DESCRIPTION
This PR delivers trimming of input fields. This prevents posting values with whitespaces in the database. It applies to the following endpoints.
1. `POST /api/v1/entries/`
2. `PUT /api/v1/entries/<entryId>/`

Manual testing can be achieved using Postman.
