### PR TITLE
Fix entry check for PUT to ensure 404 response if entry is missing

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -39,7 +39,7 @@ class EntryController:
         values = validate(request.json, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
         title = values.get('title')
         body = values.get('body')
-        if Entry.exists({'title': title, 'body': body, 'created_by': auth_id}):
+        if Entry.exists({'id': entry_id, 'title': title, 'body': body, 'created_by': auth_id}):
             return jsonify({'message': 'A similar already entry exists.'}), 409
         entry = Entry.update({'id': entry_id, 'created_by': auth_id}, title, body)
         return jsonify({'entry': entry}), 200

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,4 @@
 from flask import Flask, redirect
-from werkzeug.exceptions import HTTPException
 from app.handlers import ExceptionHandler, HttpHandler
 from app.models import ModelNotFoundException
 from app.controllers import EntryController, UserController


### PR DESCRIPTION
This PR fixes the bug arising from trying to update an entry that does not exist for the current user but exists for another user.