### PR TITLE
Fix auth api testcase class names bug

### DIFF
--- a/tests/auth_api_tests/login_test.py
+++ b/tests/auth_api_tests/login_test.py
@@ -2,7 +2,7 @@ import json
 from tests.auth_api_tests.base_test import BaseTestCase
 
 
-class SignupTestCase(BaseTestCase):
+class LoginTestCase(BaseTestCase):
 
     def setUp(self):
         BaseTestCase.setUp(self)

--- a/tests/auth_api_tests/signup_test.py
+++ b/tests/auth_api_tests/signup_test.py
@@ -2,7 +2,7 @@ import json
 from tests.auth_api_tests.base_test import BaseTestCase
 
 
-class LoginTestCase(BaseTestCase):
+class SignupTestCase(BaseTestCase):
 
     def setUp(self):
         BaseTestCase.setUp(self)


### PR DESCRIPTION
This PR fixes the incorrect naming of auth testcase class names.
