### PR TITLE
Make 404 error messages for entries more meaningful

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -5,10 +5,6 @@ from utils import NOT_FOUND_MSG, SERVER_ERROR_MSG
 
 
 class Handler:
-
-    def __init__(self):
-        pass
-
     @staticmethod
     def response_message(code, message=''):
         return make_response(jsonify({'message': message}), code)
@@ -19,21 +15,15 @@ class Handler:
 
 
 class ExceptionHandler(Handler):
-    def __init__(self):
-        pass
-
     @staticmethod
     def handle(exception):
         if type(exception) == ModelNotFoundException:
-            return Handler.response_message(404, NOT_FOUND_MSG)
+            return Handler.response_message(404, str(exception))
         if type(exception) == ValidationException:
             return Handler.response_object(422, exception.errors)
 
 
 class HttpHandler(Handler):
-    def __init__(self):
-        pass
-
     @staticmethod
     def handle(code):
         if code == 404:

--- a/app/models.py
+++ b/app/models.py
@@ -6,8 +6,10 @@ from app.database import DBQuery
 
 
 class ModelNotFoundException(Exception):
-    pass
-
+    def __init__(self, model):
+        if model == 'entry':
+            super(ModelNotFoundException, self).__init__('The entry was not found.')
+            
 
 class Entry:
     __db = DBQuery('entries')
@@ -18,7 +20,7 @@ class Entry:
     @staticmethod
     def __check(filters):
         if Entry.exists(filters) is False:
-            raise ModelNotFoundException
+            raise ModelNotFoundException('entry')
         
     @staticmethod    
     def exists(filters):

--- a/app/request.py
+++ b/app/request.py
@@ -1,5 +1,4 @@
 import re
-from app.models import User
 
 
 class ValidationException(Exception):

--- a/tests/entry_api_tests/delete_test.py
+++ b/tests/entry_api_tests/delete_test.py
@@ -28,4 +28,4 @@ class DeleteTestCase(BaseTestCase):
         response = self.delete('/api/v1/entries/71115')
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.mimetype, 'application/json')
-        self.assertEqual({"message": NOT_FOUND_MSG}, json.loads(response.data))
+        self.assertEqual({"message": "The entry was not found."}, json.loads(response.data))

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -28,7 +28,7 @@ class UpdateTestCase(BaseTestCase):
         response = self.delete('/api/v1/entries/81115')
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.mimetype, 'application/json')
-        self.assertEqual({"message": NOT_FOUND_MSG}, json.loads(response.data))
+        self.assertEqual({"message": "The entry was not found."}, json.loads(response.data))
 
     def test_fails_when_data_does_not_meet_min_length(self):
         short_data = {'title': 'Cook', 'body': 'Short'}

--- a/utils.py
+++ b/utils.py
@@ -4,9 +4,9 @@ from dotenv import load_dotenv, find_dotenv
 
 load_dotenv(dotenv_path=find_dotenv())
 
-NOT_FOUND_MSG = 'Not found.'
-SERVER_ERROR_MSG = 'Internal server error.'
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+NOT_FOUND_MSG = 'Resource not found.'
+SERVER_ERROR_MSG = 'Internal server error.'
 ROOT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 


### PR DESCRIPTION
This PR delivers a more meaningful response message for GET one, PUT and DELETE requests where entry is missing. The affected endpoints:
1. `GET /entries/<entryId>`
2. `PUT /entries/<entryId>`
3. `DELETE /entries/<entryId>`

It can be tested manually using Postman.