### PR TITLE
Remove min requirements for entry title and body

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -27,7 +27,7 @@ class EntryController:
 
     @staticmethod
     def create(auth_id):
-        values = validate(request.json, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
+        values = validate(request.json, {'title': 'required|max:255', 'body': 'required|max:1000'})
         title = values.get('title')
         body = values.get('body')
         if Entry.exists({'title': title, 'body': body, 'created_by': auth_id}):
@@ -36,7 +36,7 @@ class EntryController:
 
     @staticmethod
     def update(auth_id, entry_id):
-        values = validate(request.json, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
+        values = validate(request.json, {'title': 'required|max:255', 'body': 'required|max:1000'})
         title = values.get('title')
         body = values.get('body')
         if Entry.exists({'id': entry_id, 'title': title, 'body': body, 'created_by': auth_id}):
@@ -65,7 +65,7 @@ class UserController:
 
     @staticmethod
     def login():
-        data = validate(request.json, {'email': 'required|email', 'password': 'required|min:6'})
+        data = validate(request.json, {'email': 'required|email', 'password': 'required'})
         email = data.get('email')
         password = data.get('password')
         user = User.get_by_email(email)

--- a/tests/entry_api_tests/create_test.py
+++ b/tests/entry_api_tests/create_test.py
@@ -15,17 +15,6 @@ class CreateTestCase(BaseTestCase):
         response = self.post('/api/v1/entries/', data={'title': 'A title', 'body': 'A body to add'})
         self.assertEqual(response.status_code, 201)
 
-    def test_fails_when_data_does_not_meet_min_length(self):
-        short_data = {'title': 'Cook', 'body': 'Short'}
-        response = self.post('/api/v1/entries', data=short_data)
-        self.assertEqual(response.status_code, 422)
-        self.assertEqual(response.mimetype, 'application/json')
-        errors = {
-            'title': ['The title field must have a minimum length of 5.'],
-            'body': ['The body field must have a minimum length of 10.'],
-        }
-        self.assertEqual(errors, json.loads(response.data).get('errors'))
-
     def test_fails_when_data_exceeds_max_length(self):
         long_text = self.fake.text(1000)
         long_data = {'title': long_text, 'body': long_text + long_text}

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -30,17 +30,6 @@ class UpdateTestCase(BaseTestCase):
         self.assertEqual(response.mimetype, 'application/json')
         self.assertEqual({"message": "The entry was not found."}, json.loads(response.data))
 
-    def test_fails_when_data_does_not_meet_min_length(self):
-        short_data = {'title': 'Cook', 'body': 'Short'}
-        response = self.put('/api/v1/entries/4', data=short_data)
-        self.assertEqual(response.status_code, 422)
-        self.assertEqual(response.mimetype, 'application/json')
-        errors = {
-            'title': ['The title field must have a minimum length of 5.'],
-            'body': ['The body field must have a minimum length of 10.'],
-        }
-        self.assertEqual(errors, json.loads(response.data).get('errors'))
-
     def test_fails_when_data_exceeds_max_length(self):
         long_text = self.fake.text(1000)
         long_data = {'title': long_text, 'body': long_text + long_text}


### PR DESCRIPTION
This PR removes the min requirement for entry title and body. This gives the user more freedom and flexibility. This can be manually tested using Postman on the following endpoints:
1. `POST /entries`
2. `PUT /entries/<entryId>`