### PR TITLE
Set min validation requirement for entry title and body to 1

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -27,7 +27,7 @@ class EntryController:
 
     @staticmethod
     def create(auth_id):
-        values = validate(request.json, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
+        values = validate(request.json, {'title': 'required|min:1|max:255', 'body': 'required|min:1|max:1000'})
         title = values.get('title')
         body = values.get('body')
         if Entry.exists({'title': title, 'body': body, 'created_by': auth_id}):
@@ -36,7 +36,7 @@ class EntryController:
 
     @staticmethod
     def update(auth_id, entry_id):
-        values = validate(request.json, {'title': 'required|min:5|max:255', 'body': 'required|min:10|max:1000'})
+        values = validate(request.json, {'title': 'required|min:1|max:255', 'body': 'required|min:1|max:1000'})
         title = values.get('title')
         body = values.get('body')
         if Entry.exists({'id': entry_id, 'title': title, 'body': body, 'created_by': auth_id}):
@@ -101,7 +101,6 @@ class UserController:
             try:
                 data = jwt.decode(token, env('APP_KEY'))
                 auth_id = data.get('id')
-                print(auth_id)
             except:
                 return jsonify({'message': 'Invalid access token.'}), 401
 

--- a/tests/entry_api_tests/create_test.py
+++ b/tests/entry_api_tests/create_test.py
@@ -16,13 +16,13 @@ class CreateTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 201)
 
     def test_fails_when_data_does_not_meet_min_length(self):
-        short_data = {'title': 'Cook', 'body': 'Short'}
+        short_data = {'title': '', 'body': ''}
         response = self.post('/api/v1/entries', data=short_data)
         self.assertEqual(response.status_code, 422)
         self.assertEqual(response.mimetype, 'application/json')
         errors = {
-            'title': ['The title field must have a minimum length of 5.'],
-            'body': ['The body field must have a minimum length of 10.'],
+            'title': ['The title field must have a minimum length of 1.'],
+            'body': ['The body field must have a minimum length of 1.'],
         }
         self.assertEqual(errors, json.loads(response.data).get('errors'))
 

--- a/tests/entry_api_tests/update_test.py
+++ b/tests/entry_api_tests/update_test.py
@@ -31,13 +31,13 @@ class UpdateTestCase(BaseTestCase):
         self.assertEqual({"message": "The entry was not found."}, json.loads(response.data))
 
     def test_fails_when_data_does_not_meet_min_length(self):
-        short_data = {'title': 'Cook', 'body': 'Short'}
+        short_data = {'title': '', 'body': ''}
         response = self.put('/api/v1/entries/4', data=short_data)
         self.assertEqual(response.status_code, 422)
         self.assertEqual(response.mimetype, 'application/json')
         errors = {
-            'title': ['The title field must have a minimum length of 5.'],
-            'body': ['The body field must have a minimum length of 10.'],
+            'title': ['The title field must have a minimum length of 1.'],
+            'body': ['The body field must have a minimum length of 1.'],
         }
         self.assertEqual(errors, json.loads(response.data).get('errors'))
 


### PR DESCRIPTION
This PR sets the min requirement for entry title and body to 1. This gives the user more freedom and flexibility. This can be manually tested using Postman on the following endpoints:
1. `POST /entries`
2. `PUT /entries/<entryId>`
