### PR TITLE
#159875531 Return token expiry date on login response

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -72,10 +72,8 @@ class UserController:
         if user:
             # check the user credentials
             if User.check(email, password):
-                # generate jwt token
-                token = User.generate_token(user)
-                # return token
-                return jsonify({'token': token.decode('UTF-8')}), 200
+                # generate jwt token and return token
+                return jsonify(User.generate_token(user)), 200
         # the user gave invalid credentials
         return jsonify({'message': 'Invalid login.'}), 401
 

--- a/tests/entry_api_tests/base_test.py
+++ b/tests/entry_api_tests/base_test.py
@@ -15,7 +15,7 @@ class BaseTestCase(unittest.TestCase):
         user = self.db.create_user()
         self.user_id = user.get('id')
         self.client = app.test_client(self)
-        self.token = User.generate_token(user)
+        self.token = User.generate_token(user).get('token')
 
     def get(self, url):
         return self.client.get(url, headers={'x-access-token': self.token})


### PR DESCRIPTION
This PR delivers functionality to return expiry on the login response payload. The expiry is a UTC timestamp which ensures it is independent of the local time. This can be tested manually using Postman on the login endpoint: `POST /login`.
